### PR TITLE
added ifluatex and ifxetex to LaTeX install lines.

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -16,7 +16,7 @@ COPY . ${HOME}
 RUN chown -R ${NB_USER} ${HOME}
 
 #Installs TinyTeX for RStudio LaTeX
-RUN cd && wget -qO- "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh && tlmgr install psnfss
+RUN cd && wget -qO- "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh && tlmgr install psnfss | sh && tlmgr install ifluatex| sh && tlmgr install ifxetex
 
 ## Become normal user again
 USER ${NB_USER}


### PR DESCRIPTION
I added the following to the tinytex build/install lines:

`RUN cd && wget -qO- "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh && tlmgr install psnfss | sh && tlmgr install ifluatex| sh && tlmgr install ifxetex
`

Alternatively, we could try this apt-get before changing permissions:

`RUN apt-get update && apt-get install -y --no-install-recommends \
                                        pandoc \
                                        texlive \
                                        texlive-latex-base \
                                        texlive-latex-recommended \
                                        texlive-plain-generic
`
[TinyTex Fix suggested on LaTeX SE](https://tex.stackexchange.com/questions/529874/ifluatex-and-ifxetex-not-in-repository)