### PR TITLE
changed tinytex extension `iftex, ifluatex` install to R commands

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -16,7 +16,10 @@ COPY . ${HOME}
 RUN chown -R ${NB_USER} ${HOME}
 
 #Installs TinyTeX for RStudio LaTeX
-RUN cd && wget -qO- "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh && tlmgr install psnfss | sh && tlmgr install ifluatex| sh && tlmgr install ifxetex
+RUN cd && wget -qO- "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh && tlmgr install psnfss
+
+#| sh && tlmgr install ifluatex| sh && tlmgr install ifxetex
+RUN R -e ""tinytex::install_tinytex(extra_packages=c('iftex','ifluatex','pdftexcmds','grffile','epstopdf-pkg','lm-math','unicode-math','lualatex-math','filehook'))""
 
 ## Become normal user again
 USER ${NB_USER}


### PR DESCRIPTION
I added the following installation line to the docker file outside of the shell:

`RUN R -e ""tinytex::install_tinytex(extra_packages=c('iftex','ifluatex','pdftexcmds','grffile','epstopdf-pkg','lm-math','unicode-math','lualatex-math','filehook'))""`